### PR TITLE
Remove duplicate GA init

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,15 +40,6 @@
       gtag('config', 'G-90DMMHP3XN');
     </script>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-90DMMHP3XN"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-90DMMHP3XN');
-    </script>
 <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- clean up duplicate Google Analytics initialization in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840fc3ad2fc832b932de64d8c642210